### PR TITLE
Updates credentials used to purchase labels.

### DIFF
--- a/lib/endicia.rb
+++ b/lib/endicia.rb
@@ -70,6 +70,7 @@ module Endicia
   # Returns a Endicia::Label object.
   def self.get_label(opts={})
     customs = opts[:customs]
+    @international = !customs.nil?
     opts = defaults.merge(opts.except(:customs))
     opts[:Test] ||= "NO"
     url = "#{label_service_url(opts)}/GetPostageLabelXML"
@@ -460,11 +461,17 @@ module Endicia
 
   # Prefer to keep credentials in env vars than in YAML, so here we are:
   def self.environment_overrides
-    mappings = {
-      "ENDICIA_ACCOUNT_ID"   => "AccountID",
-      "ENDICIA_REQUESTER_ID" => "RequesterID",
-      "ENDICIA_PASSPHRASE"   => "PassPhrase" }
-
+    if @international
+      mappings = {
+        "ENDICIA_ACCOUNT_ID_INTERNATIONAL"   => "AccountID",
+        "ENDICIA_REQUESTER_ID" => "RequesterID",
+        "ENDICIA_PASSPHRASE_INTERNATIONAL"   => "PassPhrase" }
+    else
+      mappings = {
+        "ENDICIA_ACCOUNT_ID"   => "AccountID",
+        "ENDICIA_REQUESTER_ID" => "RequesterID",
+        "ENDICIA_PASSPHRASE"   => "PassPhrase" }
+    end
     mappings.each_with_object({}) { |(k,v), memo|
       unless (val = ENV[k].to_s.strip).empty?
         val = val.to_i if k.include?("ACCOUNT_ID")


### PR DESCRIPTION
This commit updates the credentials used to purchase postage. It would
seem that _Endicia_ requires two different accounts to get corresponding
discounts for international and domestic shipments. This commit allows
the use of the credentials for the international account to be used for
the international shipments. This also needs two additional environment vars one called `ENDICIA_ACCOUNT_ID_INTERNATIONAL` and another called `ENDICIA_PASSPHRASE_INTERNATIONAL`. The values used for these are the same as the type of credentials used for the original account, but for the international account.