### PR TITLE
Fixes issues with non-utf8 characters.

### DIFF
--- a/lib/endicia/zplii_label.rb
+++ b/lib/endicia/zplii_label.rb
@@ -18,17 +18,15 @@ module Endicia
         raise LabelError, (data["ErrorMessage"] || result.body.to_s)
       end
 
-      if encoded_zpl.is_a?(String)
-        decoded_zpl = Base64.decode64(encoded_zpl)
-      elsif encoded_zpl.is_a?(Array)
-        decoded_zpl = data["Label"]["Image"].map{|label| Base64.decode64(label["__content__"])}.join("")
+      if encoded_zpl.is_a?(Array)
+        encoded_zpl = data["Label"]["Image"].map{|label| label["__content__"]}.join("&:surlysquid:&")
       elsif encoded_zpl.is_a?(Hash)
-        decoded_zpl = Base64.decode64(data["Label"]["Image"]["__content__"])
+        encoded_zpl = data["Label"]["Image"]["__content__"]
       end
 
 
       @tracking_number   = data["TrackingNumber"]
-      @image             = decoded_zpl
+      @image             = encoded_zpl
     end
   end
 end


### PR DESCRIPTION
This commit adjusts the parsing of the response from the _Endicia_ api.
Previously, the label was decoded within the gem, but this has been
changed, so the returned label remains base64 encoded. This will allow
the `TubeDepot/tubedepot-spree2` application to save it in the database
as a base64 encoded string. This string will then be send to the print
server where it will be decoded and printed. This was done to help with
labels that contain odd or foreign characters that are difficult to
encoded as utf-8.