### PR TITLE
Adjusts the way non-ZPLII labels are handled.

### DIFF
--- a/lib/endicia/label.rb
+++ b/lib/endicia/label.rb
@@ -14,14 +14,11 @@ module Endicia
                   :cost_center,
                   :request_body,
                   :request_url,
-                  :response_body
+                  :response_body,
+                  :requester_id
     def initialize(result)
       self.response_body = filter_response_body(result.body.dup)
-      data = result["LabelRequestResponse"] || {}
-      data.each do |k, v|
-        k = "image" if k == 'Base64LabelImage'
-        send(:"#{k.tableize.singularize}=", v) if !k['xmlns']
-      end
+      self.image = result["LabelRequestResponse"]["Base64LabelImage"]
     end
     
     private


### PR DESCRIPTION
This commit fixes an issue with the way non-ZPLII labels are handled.
This was done in an attempt to purchase return labels through _Endicia_
which will be in pdf format.